### PR TITLE
Bug handling quotes on $tags

### DIFF
--- a/plugin/ctags.vim
+++ b/plugin/ctags.vim
@@ -217,9 +217,9 @@ if has('perl')
 	close (CTAGS);
 
 	$lines .= $max_num;
-	$lines .= $max_num;
+	$tags  = quotemeta($tags);
 
-	VIM::DoCommand("let b:tags = '$tags'");
+	VIM::DoCommand(qq(let b:tags = "$tags"));
 	VIM::DoCommand("let b:length = $length");
 	VIM::DoCommand("let b:lines = '$lines'");
 PERL_EOF


### PR DESCRIPTION
Perl file:
```perl
use Foo ':foo';
use Bar ":bar";
```
Generate ctags files with: `ctags .`

When opening the Perl file in VIM, then the plugin will crash due to quotes messing with the expression generation.